### PR TITLE
Limit per_page in the Links header to max_per_page

### DIFF
--- a/lib/paginate-responder/paginator.rb
+++ b/lib/paginate-responder/paginator.rb
@@ -45,7 +45,9 @@ module PaginateResponder
     end
 
     def link!(rel, page)
-      response.link(controller.url_for(request.params.merge(:page => page)), :rel => rel)
+      pagination_params = { :page => page }
+      pagination_params[:per_page] = per_page if request.params.has_key?(:per_page)
+      response.link(controller.url_for(request.params.merge(pagination_params)), :rel => rel)
     end
 
     def resource!

--- a/test/paginate_responder_test.rb
+++ b/test/paginate_responder_test.rb
@@ -212,6 +212,21 @@ class PaginateResponderTest < ActionController::TestCase
     assert_equal 'http://test.host/index.json?page=68&per_page=10', response.links[2][:url]
   end
 
+  def test_headers_per_page_maximum
+    get :index, format: :json, page: 1, per_page: 100
+
+    assert_equal 3, response.links.size
+
+    assert_equal 'first', response.links[0][:params][:rel]
+    assert_equal 'http://test.host/index.json?page=1&per_page=50', response.links[0][:url]
+
+    assert_equal 'next', response.links[1][:params][:rel]
+    assert_equal 'http://test.host/index.json?page=2&per_page=50', response.links[1][:url]
+
+    assert_equal 'last', response.links[2][:params][:rel]
+    assert_equal 'http://test.host/index.json?page=14&per_page=50', response.links[2][:url]
+  end
+
   def test_headers_total_pages
     get :index, format: :json
 


### PR DESCRIPTION
When the client requests per_page that is higher than max_per_page, the generated links should include max_per_page instead of the requested per_page value.