### PR TITLE
Added support for pagy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
 env:
   - GEM=will_paginate
   - GEM=kaminari
+  - GEM=pagy
 gemfile:
   - gemfiles/rails_4_2.gemfile
   - gemfiles/rails_5_0.gemfile
@@ -26,6 +27,10 @@ jobs:
       gemfile: gemfiles/rails_5_2.gemfile
     - rvm: '2.1.10'
       gemfile: gemfiles/rails_head.gemfile
+    - rvm: '2.2.10'
+      env: GEM=pagy
+    - rvm: '2.1.10'
+      env: GEM=pagy
   allow_failures:
     - gemfile: gemfiles/rails_head.gemfile
   include:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Or install it yourself as:
 You will also need a pagination gem. `PaginateResponder` comes with adapters for
 * [will_paginate](https://github.com/mislav/will_paginate)
 * [kaminari](https://github.com/amatsuda/kaminari).
+* [pagy](https://github.com/ddnexus/pagy).
 
 It is recommended to use only one pagination gem at once.
 

--- a/lib/paginate-responder.rb
+++ b/lib/paginate-responder.rb
@@ -9,4 +9,5 @@ module PaginateResponder
   require 'paginate-responder/base'
   require 'paginate-responder/will_paginate_adapter'
   require 'paginate-responder/kaminari_adapter'
+  require 'paginate-responder/pagy_adapter'
 end

--- a/lib/paginate-responder/pagy_adapter.rb
+++ b/lib/paginate-responder/pagy_adapter.rb
@@ -1,0 +1,51 @@
+module PaginateResponder
+  #
+  # Pagination adapter for pagy.
+  #
+  class PagyAdapter < Base
+    def paginate
+      self.pagy, self.pagy_resource = controller.send(self.class.pagy_method(resource), resource, page: page, items: per_page)
+      pagy_resource
+    end
+
+    def total_pages
+      pagy.pages
+    end
+
+    def total_count
+      pagy.count
+    end
+
+    def default_per_page
+      Pagy::VARS[:items]
+    end
+
+    def default_max_per_page
+      Pagy::VARS[:max_items] || BigDecimal::INFINITY
+    end
+
+    def paginate!
+      paginate.tap do
+        update
+      end
+    end
+
+    class << self
+      def suitable?(resource, responder)
+        responder.controller.respond_to?(pagy_method(resource), true)
+      end
+
+      def pagy_method(resource)
+        %i[limit offset].all? { |model_method| resource.respond_to?(model_method) } ? :pagy : :pagy_array
+      end
+    end
+
+    private
+
+    attr_accessor :pagy, :pagy_resource
+  end
+
+  if defined?(:Pagy)
+    ::Responders::PaginateResponder.register PagyAdapter
+  end
+end

--- a/paginate-responder.gemspec
+++ b/paginate-responder.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'activerecord', '>= 3.2.0'
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'kaminari'
+  gem.add_development_dependency 'pagy'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'pry-byebug'
   gem.add_development_dependency 'rake'

--- a/spec/paginate_responder_spec.rb
+++ b/spec/paginate_responder_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 RSpec.describe Responders::PaginateResponder, type: :controller do
   case $gem
-    when 'will_paginate'
+    when 'will_paginate',
+         'pagy'
       let(:array_resource) do
         ('AA'..'zz').to_a
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,15 @@ case $gem
       config.default_per_page = 50
       config.max_per_page = 50
     end
+  when 'pagy'
+    require 'pagy'
+    require 'pagy/extras/array'
+    require 'pagy/extras/items'
+
+    TestController.include(Pagy::Backend)
+
+    Pagy::VARS[:items] = 50
+    Pagy::VARS[:max_items] = 50
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Pagy is another pagination gem:

https://github.com/ddnexus/pagy

I've added support for it alongside will_paginate and kaminari, using
those as a guide.

The main difference between pagy and the other two is that it doesn't
add scope methods to ActiveRecord::Base but instead paginates using a
controller helper method.