### PR TITLE
Handle invalid ?page parameter 

### DIFF
--- a/lib/paginate-responder/base.rb
+++ b/lib/paginate-responder/base.rb
@@ -56,6 +56,8 @@ module PaginateResponder
 
     def cast_page(page)
       Integer(page)
+    rescue ArgumentError
+      1
     end
 
     def per_page

--- a/spec/paginate_responder_spec.rb
+++ b/spec/paginate_responder_spec.rb
@@ -40,6 +40,22 @@ RSpec.describe Responders::PaginateResponder, type: :controller do
       it { expect(json).to eq (51..100).to_a }
     end
 
+    describe '?page empty' do
+      let(:params) { super().merge page: '' }
+
+      it 'responds with first page' do
+        expect(json).to eq (1..50).to_a
+      end
+    end
+
+    describe '?page invalid' do
+      let(:params) { super().merge page: 'foobar' }
+
+      it 'responds with first page' do
+        expect(json).to eq (1..50).to_a
+      end
+    end
+
     describe '?per_page' do
       let(:params) { super().merge per_page: 10 }
 


### PR DESCRIPTION
Be liberal in what you accept...

This makes it harder for "bad" actors to cause exceptions and error responses.