### PR TITLE
Overwrite respond, not to_format

### DIFF
--- a/lib/responders/paginate_responder.rb
+++ b/lib/responders/paginate_responder.rb
@@ -1,6 +1,6 @@
 module Responders
   module PaginateResponder
-    def to_format
+    def respond
       paginate! if get?
 
       super


### PR DESCRIPTION
For compatibility with DecorateResponder 2.0.

See https://github.com/jgraichen/decorate-responder/pull/3.